### PR TITLE
[ADD] base_geoengine: full screen control, show line length while drawing, create property boundary on geoengine view

### DIFF
--- a/base_geoengine/static/src/js/views/geoengine/geoengine_controller/geoengine_controller.esm.js
+++ b/base_geoengine/static/src/js/views/geoengine/geoengine_controller/geoengine_controller.esm.js
@@ -74,7 +74,6 @@ export class GeoengineController extends Component {
         const {views} = await this.view.loadViews({resModel, views: [[false, "form"]]});
         const context = {};
         context[`default_${field}`] = value;
-        debugger
         this.addDialog(FormViewDialog, {
             resModel: resModel,
             title: this.env._t("New record"),

--- a/base_geoengine/static/src/js/widgets/geoengine_edit_map/field.geoengine_edit_map.scss
+++ b/base_geoengine/static/src/js/widgets/geoengine_edit_map/field.geoengine_edit_map.scss
@@ -146,7 +146,12 @@ $ol-tooltip-bg-color: rgba(0, 0, 0, 0.5);
 
 }
 
-.ol-remove-interaction-control {
+.ol-fs-control {
     top: 160px;
+    left: 0.5em;
+}
+
+.ol-remove-interaction-control {
+    top: 180px;
     left: 0.5em;
 }


### PR DESCRIPTION
### **This PR adds the following features:**

- full screen control
- show line length while drawing
- create property boundary on geoengine view


**Evidence**

**Full Screen Map**
![image](https://github.com/Vauxoo/geospatial/assets/76703666/a43c81c0-d605-4069-8c82-7933405fdf1f)


**Line Length in KM**
![image](https://github.com/Vauxoo/geospatial/assets/76703666/205005a7-779f-4797-bcaa-7ee46d024933)

**Create property boundaries on geoengine view**
![image](https://github.com/Vauxoo/geospatial/assets/76703666/c58a4618-5bb9-4782-9129-90239562d4aa)


