### PR TITLE
base_geoengine: [ADD] New Map Features

### DIFF
--- a/base_geoengine/static/src/js/constants.js
+++ b/base_geoengine/static/src/js/constants.js
@@ -57,4 +57,8 @@ export  const LAND_TYPES = [
     },
 ];
 export const VIEW_TYPE_GEOENGINE = 'geoengine';
+export const FEATURE_TYPES = {
+    GEOPOINT: 'geopoint',
+    CHILD: 'child',
+}
 

--- a/base_geoengine/static/src/js/helpers.js
+++ b/base_geoengine/static/src/js/helpers.js
@@ -1,0 +1,25 @@
+/** @odoo-module **/
+
+/**
+ * Generates a unique ID.
+ *
+ * This function uses the `crypto.getRandomValues` method to generate a unique ID. 
+ * It creates a new typed array with one element (`Uint32Array(1)`) and fills it with cryptographically strong random values.
+ *
+ * @returns {number} The generated unique ID, which is a number.
+ */
+export function isTouchDevice() {
+    return window.matchMedia("(pointer: coarse)").matches;
+}
+
+/**
+ * Generates a unique ID.
+ *
+ * This function uses the `crypto.getRandomValues` method to generate a unique ID. 
+ * It creates a new typed array with one element (`Uint32Array(1)`) and fills it with cryptographically strong random values.
+ *
+ * @returns {number} The generated unique ID, which is a number.
+ */
+export function uniqueID() {
+    return crypto.getRandomValues(new Uint32Array(1))[0];
+}

--- a/base_geoengine/static/src/js/views/geoengine/geoengine_controller/geoengine_controller.esm.js
+++ b/base_geoengine/static/src/js/views/geoengine/geoengine_controller/geoengine_controller.esm.js
@@ -74,7 +74,6 @@ export class GeoengineController extends Component {
         const {views} = await this.view.loadViews({resModel, views: [[false, "form"]]});
         const context = {};
         context[`default_${field}`] = value;
-        debugger
         this.addDialog(FormViewDialog, {
             resModel: resModel,
             title: this.env._t("New record"),

--- a/base_geoengine/static/src/js/widgets/geoengine_edit_map/field.geoengine_edit_map.scss
+++ b/base_geoengine/static/src/js/widgets/geoengine_edit_map/field.geoengine_edit_map.scss
@@ -113,11 +113,6 @@ $ol-tooltip-bg-color: rgba(0, 0, 0, 0.5);
     }
 }
 
-.ol-clear {
-    top: 140px;
-    left: 0.5em;
-}
-
 .ol-polygon-type-control {
     max-width: 8.8rem;
     background-color: white;
@@ -135,23 +130,34 @@ $ol-tooltip-bg-color: rgba(0, 0, 0, 0.5);
     }
 }
 
-.ol-geopoints-control {
-    top: 120px;
+@mixin control-position($top, $top-md) {
+    top: $top;
     left: 0.5em;
+    @include media-breakpoint-up(md) {
+        top: $top-md;
+    }
 }
 
 .ol-home-control {
-    top: 100px;
-    left: 0.5em;
+    @include control-position(100px, 100px);
+}
 
+.ol-geopoints-control {
+    @include control-position(130px, 120px);
+}
+
+.ol-clear {
+    @include control-position(160px, 140px);
+}
+
+.ol-edit-land-control {
+    @include control-position(190px, 160px);
 }
 
 .ol-fs-control {
-    top: 160px;
-    left: 0.5em;
+    @include control-position(230px, 180px);
 }
 
 .ol-remove-interaction-control {
-    top: 180px;
-    left: 0.5em;
+    @include control-position(240px, 200px);
 }

--- a/base_geoengine/static/src/js/widgets/geoengine_edit_map/field.geoengine_edit_map.scss
+++ b/base_geoengine/static/src/js/widgets/geoengine_edit_map/field.geoengine_edit_map.scss
@@ -146,7 +146,12 @@ $ol-tooltip-bg-color: rgba(0, 0, 0, 0.5);
 
 }
 
-.ol-remove-interaction-control {
+.ol-fs-control {
     top: 160px;
+    left: 0.5em;
+}
+
+.ol-remove-interaction-control {
+    top: 180px;
     left: 0.5em;
 }


### PR DESCRIPTION
**Overview**

### **This PR adds the following features:**

- full screen control
- show line length while drawing
- create property boundary on geoengine view
- A land editing control , allowing users to modify land parcels and geographic points with enhanced precision.

**Editing**
- Property Boundary Editing:
Users can now edit property boundaries. Any geometries left outside the adjusted boundary will be automatically removed upon confirmation.

- Handling Geometries Outside Boundaries:
When a property boundary is edited, if any associated child lands or geopoints are positioned outside the new boundaries, these changes will be discarded when the confirmation dialog is accepted.

**Full Screen Map**
![image](https://github.com/Vauxoo/geospatial/assets/76703666/a43c81c0-d605-4069-8c82-7933405fdf1f)


**Line Length in KM**
![image](https://github.com/Vauxoo/geospatial/assets/76703666/205005a7-779f-4797-bcaa-7ee46d024933)

**Create property boundaries on geoengine view**
![image](https://github.com/Vauxoo/geospatial/assets/76703666/c58a4618-5bb9-4782-9129-90239562d4aa)

**Edit Control**
![image](https://github.com/Vauxoo/geospatial/assets/76703666/d32c28f9-b2db-4320-b91f-9f127242ccb1)
