### PR TITLE
[ADD] base_geoengine: SearchBar component in GeoengineController Component

### DIFF
--- a/base_geoengine/static/src/js/views/geoengine/geoengine_controller/geoengine_controller.esm.js
+++ b/base_geoengine/static/src/js/views/geoengine/geoengine_controller/geoengine_controller.esm.js
@@ -13,6 +13,8 @@ import { WarningDialog } from "@web/core/errors/error_dialogs";
 import { Component, useState } from "@odoo/owl";
 import { addFieldDependencies, extractFieldsFromArchInfo } from "@web/model/relational_model/utils";
 import { _t } from "@web/core/l10n/translation";
+import { SearchBar } from "@web/search/search_bar/search_bar";
+
 
 export class GeoengineController extends Component {
     /**
@@ -173,7 +175,7 @@ export class GeoengineController extends Component {
 }
 
 GeoengineController.template = "base_geoengine.GeoengineController";
-GeoengineController.components = { Layout };
+GeoengineController.components = { Layout, SearchBar };
 GeoengineController.props = {
     archInfo: Object,
     fields: Object,

--- a/base_geoengine/static/src/js/views/geoengine/geoengine_controller/geoengine_controller.xml
+++ b/base_geoengine/static/src/js/views/geoengine/geoengine_controller/geoengine_controller.xml
@@ -2,6 +2,9 @@
 <templates>
     <t t-name="base_geoengine.GeoengineController" owl="1">
         <Layout display="props.display" className="'h-100'">
+            <t t-set-slot="layout-actions">
+                <SearchBar/>
+            </t>
             <t t-set-slot="layout-buttons">
                 <t t-if="model.root.editedRecord">
                     <button

--- a/base_geoengine/static/src/js/widgets/domain_selector_geo_field/domain_selector_number_field/domain_selector_number_field.esm.js
+++ b/base_geoengine/static/src/js/widgets/domain_selector_geo_field/domain_selector_number_field/domain_selector_number_field.esm.js
@@ -7,8 +7,6 @@
 import { registry } from "@web/core/registry";
 import { _lt } from "@web/core/l10n/translation";
 import { DomainSelectorFieldInputForActiveIds } from "../domain_selector_field_input_for_active_ids/domain_selector_field_input_for_active_ids.esm";
-// import {DomainSelectorFieldInput} from "@web/core/domain_selector/fields/domain_selector_field_input";
-// import {DomainSelectorFieldInputWithTags} from "@web/core/domain_selector/fields/domain_selector_field_input_with_tags";
 import { onDidChange } from "../domain_selector_operators.esm";
 import { Component } from "@odoo/owl";
 
@@ -21,8 +19,6 @@ export class DomainSelectorNumberFieldExtend extends Component {}
 Object.assign(DomainSelectorNumberFieldExtend, {
     template: "base_geoengine.DomainSelectorNumberFieldExtend",
     components: {
-        // DomainSelectorFieldInput,
-        // DomainSelectorFieldInputWithTags,
         DomainSelectorFieldInputForActiveIds,
     },
 


### PR DESCRIPTION
**Overview**
The searchbar filters was missing on v17.0, because it is different  than v16.

![image](https://github.com/Vauxoo/geospatial/assets/76703666/d3cd4991-6936-408c-a96d-cc83e2247195)
