### PR TITLE
[MIG] vector and layers in geoengine view

### DIFF
--- a/base_geoengine/geo_db.py
+++ b/base_geoengine/geo_db.py
@@ -81,7 +81,7 @@ def _postgis_index_name(table, col_name):
 def create_geo_index(env, columnname, tablename):
     """Create the given index unless it exists."""
     indexname = _postgis_index_name(tablename, columnname)
-    if sql.index_exists(env.cr, indexname):
+    if sql.index_exists(env, indexname):
         return
     # pylint: disable=E8103
     env.cr.execute(

--- a/base_geoengine/models/geo_raster_layer.py
+++ b/base_geoengine/models/geo_raster_layer.py
@@ -24,6 +24,7 @@ class GeoRasterLayer(models.Model):
             ("wmts", "WMTS"),
             ("d_wms", "Distant WMS"),
             ("odoo", "Odoo field"),
+            ("map_box", "Mapbox")
         ],
         string="Raster layer type",
         default="osm",

--- a/base_geoengine/static/src/js/constants.js
+++ b/base_geoengine/static/src/js/constants.js
@@ -67,3 +67,5 @@ export const DEFAULT_MIN_SIZE = 5;
 export const DEFAULT_MAX_SIZE = 15;
 export const DEFAULT_NUM_CLASSES = 5;
 export const LEGEND_MAX_ITEMS = 10;
+export const PROJECT_AGRICULTURE_SCOUT_MODEL = "project.agriculture.scout";
+export const PROJECT_AGRICULTURE_LAND_MODEL = "project.agriculture.land";

--- a/base_geoengine/static/src/js/views/geoengine/geoengine_controller/geoengine_controller.esm.js
+++ b/base_geoengine/static/src/js/views/geoengine/geoengine_controller/geoengine_controller.esm.js
@@ -61,7 +61,7 @@ export class GeoengineController extends Component {
      * @param {*} resModel
      * @param {*} resId
      */
-    async openRecord(resModel, resId) {
+    async openRecord(resModel, resId, context={ edit: true, create: false }) {
         const { views } = await this.view.loadViews({ resModel, views: [[false, "form"]] });
         this.actionService.doAction({
             type: "ir.actions.act_window",
@@ -69,7 +69,7 @@ export class GeoengineController extends Component {
             views: [[views.form.id, "form"]],
             res_id: resId,
             target: "new",
-            context: { edit: false, create: false },
+            context,
         });
     }
 
@@ -98,6 +98,8 @@ export class GeoengineController extends Component {
     async onSaveRecord() {
         await this.model.root.load();
         this.render(true);
+        // TODO: check if this reload is necesary
+        // window.location.reload();
     }
 
     /**

--- a/base_geoengine/static/src/js/views/geoengine/geoengine_renderer/geoengine_renderer.scss
+++ b/base_geoengine/static/src/js/views/geoengine/geoengine_renderer/geoengine_renderer.scss
@@ -65,3 +65,21 @@
 .ol-popup-closer:after {
     content: "✖";
 }
+@mixin control-position($top, $top-md, $left: 0.5em) {
+    top: $top;
+    left: $left;
+    @include media-breakpoint-up(md) {
+        top: $top-md;
+    }
+}
+.fs-control {
+    @include control-position(130px, 110px)
+}
+.geocoder-control-geoengine {
+    .gcd-gl-control {
+        &.ol-control {
+            background-color: transparent;
+        }
+        @include control-position(80px, 80px, 0.1em)
+    }
+}

--- a/base_geoengine/static/src/js/views/geoengine/layers_panel/layers_panel.xml
+++ b/base_geoengine/static/src/js/views/geoengine/layers_panel/layers_panel.xml
@@ -2,7 +2,7 @@
 <templates>
     <t t-name="base_geoengine.LayersPanel" owl="1">
         <div
-            class="menu border-end"
+            class="menu border-end overflow-auto"
             t-attf-class="{{ state.isFolded ? 'o_layer_panel_fold ' : 'o_layer_panel bg-view' }}"
         >
             <div
@@ -26,10 +26,11 @@
                     </header>
                     <div t-ref="root" class="root">
                         <ul class="list p-0">
+                            <!-- TODO: replace the t-key -->
                             <li
                                 t-foreach="state.geoengineLayers.actives"
                                 t-as="vector"
-                                t-key="vector.resId"
+                                t-key="vector.name"
                                 class="item d-flex align-items-center"
                                 t-att-data-id="vector.id"
                             >
@@ -41,7 +42,10 @@
                                         value="vector.isVisible"
                                         t-on-change="() => this.onVectorChange(vector, 'onVisibleChanged', !vector.isVisible)"
                                     >
-                                        <span t-esc="vector.name" class="text-break"/>
+                                        <div class="d-flex align-items-center" style="gap: 0 1rem;">
+                                            <t t-esc="vector.name" />
+                                            <div t-attf-style="width: 1rem; height: 1rem; background-color: {{vector.begin_color}};"/>
+                                        </div>
                                     </CheckBox>
                                     <button
                                         t-if="vector.model_id &amp; isGeoengineAdmin"

--- a/base_geoengine/static/src/js/views/geoengine/records_panel/records_panel.xml
+++ b/base_geoengine/static/src/js/views/geoengine/records_panel/records_panel.xml
@@ -27,7 +27,7 @@
                         </span>
                     </header>
                     <SearchBarRecords onInputKeyup.bind="onInputKeyup" />
-                    <ul class="raster list-group d-block o_search_panel_field mt-2">
+                    <ul t-if="state.records.length > 0" class="raster list-group d-block o_search_panel_field mt-2">
                         <li
                             class="mb-1 record d-flex justify-content-between border"
                             t-foreach="state.records"
@@ -64,6 +64,9 @@
                             </t>
                         </li>
                     </ul>
+                    <p t-else="" class="mt-2 fw-bold text-danger px-2">
+                        No records found
+                    </p>
                 </section>
             </div>
             <div t-else="" class="d-flex justify-content-center text-900">

--- a/base_geoengine/static/src/js/widgets/domain_selector_geo_field/domain_selector_geo_field_input/domain_selector_geo_field_input.esm.js
+++ b/base_geoengine/static/src/js/widgets/domain_selector_geo_field/domain_selector_geo_field_input/domain_selector_geo_field_input.esm.js
@@ -99,7 +99,7 @@ export class DomainSelectorGeoFieldInput extends Component {
             isDebugMode: Boolean(this.env.debug),
             fieldName: this.state.fieldName,
             onSelected: (value) => this.update(value),
-            title: this.env._t("Subdomain"),
+            title: _t("Subdomain"),
         });
     }
 

--- a/base_geoengine/static/src/js/widgets/geoengine_edit_map/field_geoengine_edit_map.esm.js
+++ b/base_geoengine/static/src/js/widgets/geoengine_edit_map/field_geoengine_edit_map.esm.js
@@ -419,8 +419,6 @@ export class FieldGeoEngineEditMap extends Component {
             });
 
         } else {
-            if (this.isGeoengineView) return;
-
             const editLandControl = this.createEditLandControl()
             this.editLandControl = new ol.control.Control({ element: editLandControl });
             this.map.addControl(this.editLandControl);
@@ -659,7 +657,8 @@ export class FieldGeoEngineEditMap extends Component {
                     const record = await this.createRecord({
                         longitude,
                         latitude,
-                        land_id: this.props.record.data.id
+                        land_id: this.props.record.data.id,
+                        geopoint: this.format.writeGeometry(e.feature.getGeometry()),
                     }, "project.agriculture.scout", removeLayer)
                     if (!record) return;
                     const { name } = record.data
@@ -1241,7 +1240,8 @@ export class FieldGeoEngineEditMap extends Component {
             internalProjection: this.map.getView().getProjection(),
             externalProjection: "EPSG:" + this.srid,
         });
-        if (!this.props.readonly && this.props.record.data.city_id) this.setupControls();
+        // TODO: maybe the id is not in this key
+        if (!this.props.readonly && this.map && this.props.record.data?.id) this.setupControls();
         if (this.mapBoxToken) {
             this.map.on('pointermove', (e) => {
                 const feature = this.map.forEachFeatureAtPixel(e.pixel, f => f);


### PR DESCRIPTION



This PR enhances the geoengine view by:

- Allowing customization of the property boundary form view.
- Introducing FullScreen and Search functionalities.
- Adding a LayersPanel for map layer switching similar to the form view.
- Incorporating all land types for comprehensive visualization.
- Implementing a rule to prevent map overlaps for clearer data presentation.

